### PR TITLE
create img_split_dota.py file for dota dataset

### DIFF
--- a/tools/split_configs/dota1_0/ms_trainval.json
+++ b/tools/split_configs/dota1_0/ms_trainval.json
@@ -28,6 +28,7 @@
         104, 116, 124
     ],
     "filter_empty": true,
+    "generate_txt": true,
     "save_dir": "data/split_ms_dota1_0/trainval/",
     "save_ext": ".png"
 }


### PR DESCRIPTION
I want to generate annotation .txt for splitted image.
but, img_split.py create just .pkl files.

So, I create new file img_split_dota.py file.
It can make the annotation .txt file for spllitted image. 

Please review this PR.